### PR TITLE
Only declare root once per server

### DIFF
--- a/contrib/conf/nginx.conf
+++ b/contrib/conf/nginx.conf
@@ -59,7 +59,6 @@ server {
 
         ## Regular PHP processing.
         location ~ \.php$ {
-            root           html;
             try_files  $uri =404;
             fastcgi_pass   php_processes;
             fastcgi_index  index.php;
@@ -128,7 +127,6 @@ server {
 
         ## Regular PHP processing.
         location ~ \.php$ {
-            root           html;
             try_files  $uri =404;
             fastcgi_pass   php_processes;
             fastcgi_index  index.php;


### PR DESCRIPTION
Removed redundant `root` directives to make it less confusing to switch the document root to .e.g. `C:\Projects\example.com`.