### PR TITLE
Fixd when startup,php will start with default version.

### DIFF
--- a/Wnmp/readme.txt
+++ b/Wnmp/readme.txt
@@ -1,3 +1,9 @@
+I don't know whether the author will update or not.
+His HomePage has been down.
+Now I will fix some bugs for this Project.
+2018/01/26 Nash-x9
+
+==================================================================
 Copyright (c) 2012 - 2017, Kurt Cancemi (kurt@x64architecture.com)
 Donations are appreciated no matter if big or small via Amazon.
 https://wnmp.x64architecture.com/donate/

--- a/src/Wnmp/Wnmp.UI/MainFrm.cs
+++ b/src/Wnmp/Wnmp.UI/MainFrm.cs
@@ -253,7 +253,16 @@ namespace Wnmp.UI
             Log.Notice("Wnmp Directory: " + Program.StartupPath);
             SetupNginx();
             SetupMariaDB();
-            SetupPHP();
+            /*Updated By Nash-x9:Fixd when startup,php will start with default version.*/
+            if (Properties.Settings.Default.PHPVersion == "Default")
+            {
+                SetupPHP();
+            }
+            else
+            {
+                SetupCustomPHP();
+            }
+            /*Updated End*/
             SetupConfigAndLogMenuStrips();
             SetupTrayMenu();
             updater = new WnmpUpdater(this);


### PR DESCRIPTION
Fixd when startup,php will start with default version.
#101 #97 
修复当WNMP启动时，启用的是默认的PHP版本。现在当用户设置了自己的PHP版本，启动时默认启动用户设置的PHP版本。